### PR TITLE
Improve inline documentation

### DIFF
--- a/driver/start-dbus-epever-tracer.sh
+++ b/driver/start-dbus-epever-tracer.sh
@@ -12,4 +12,7 @@
 
 # Command to run the driver
 app="python /opt/victronenergy/dbus-epever-tracer/dbus-epever-tracer.py"
+# ``$tty`` is provided by serial-starter and contains the name of the serial
+# device to use, e.g. ttyUSB0.  The helper function ``start`` comes from
+# ``run-service.sh`` and takes care of respawning the driver when it exits.
 start /dev/$tty


### PR DESCRIPTION
## Summary
- expand module docstring explaining driver purpose and features
- document `DbusEpever` init arguments
- clarify periodic update behavior
- add notes to `main` entry point
- explain `$tty` usage in start script

## Testing
- `python3 -m py_compile driver/dbus-epever-tracer.py`
- `shellcheck driver/start-dbus-epever-tracer.sh | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68420c48eb04832fb01d121b15508457