### PR TITLE
chore: remove unused imports and duplicate time import

### DIFF
--- a/driver/dbus-epever-tracer.py
+++ b/driver/dbus-epever-tracer.py
@@ -42,17 +42,8 @@ import os
 import logging
 import traceback
 import time
-import math
 import datetime
 from datetime import datetime, date
-from asyncio import exceptions
-import gettext
-import time
-
-# ===============================
-# Standard library imports
-# ===============================
-import argparse
 from gi.repository import GLib  # For main event loop
 import dbus
 import dbus.service  # For DBus service implementation


### PR DESCRIPTION
Removes math, gettext, asyncio.exceptions, argparse, and the duplicate import time from the driver file. These were never referenced in the code.

Closes #8

Generated with [Claude Code](https://claude.ai/code)